### PR TITLE
Fix chunk uploaded event

### DIFF
--- a/lib/upload-stream.js
+++ b/lib/upload-stream.js
@@ -87,7 +87,7 @@ UploadStream.prototype._uploadBuffer = function UploadStreamPushBuffer (callback
   this._pending++;
   this._uploader.push(data, function () {
     self.bytesWritten += data.length;
-    self.emit("chunk-uploaded", self._uploader._uploaded.length);
+    self.emit("chunk-uploaded");
     if (callback) {
       callback();
     }


### PR DESCRIPTION
Removes some invalid argumenta that are only on the mock uploader from the non-mock implementation.