### PR TITLE
Fix chunk uploaded event

### DIFF
--- a/lib/upload-stream.js
+++ b/lib/upload-stream.js
@@ -28,6 +28,7 @@ function UploadStream (uploader, options) {
   this._pending = 0;
   this._options = options || {};
   this._concurrent = this._options.concurrent || 1;
+  this._chunksUploaded = 0;
   this._buffers = [];
   this._buffersLength = 0;
   this._uploader = uploader;
@@ -87,7 +88,7 @@ UploadStream.prototype._uploadBuffer = function UploadStreamPushBuffer (callback
   this._pending++;
   this._uploader.push(data, function () {
     self.bytesWritten += data.length;
-    self.emit("chunk-uploaded", self._uploader._uploaded.length);
+    self.emit("chunk-uploaded",  ++self._chunksUploaded);
     if (callback) {
       callback();
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "2.0.0-rc13",
+    "aws-sdk": "^2.1.16",
     "underscore": "^1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Removes some invalid arguments that are only on the mock uploader and replaces with values from upload-stream.js