### PR TITLE
pass arguments to the done function when finish is called

### DIFF
--- a/lib/upload-stream.js
+++ b/lib/upload-stream.js
@@ -110,9 +110,11 @@ UploadStream.prototype._uploadBuffer = function UploadStreamPushBuffer (callback
  */
 
 UploadStream.prototype._final = function UploadStreamEnd (done) {
-  this._uploader.once("finish", function () {
-    done()
-  });
+  var self = this;
+  this._uploader.once("finish", function(res) {
+    done();
+    self.emit('finishWithArgs', res)
+  })
 
   if (this.queue.length()) {
     this._uploadBuffer();


### PR DESCRIPTION
was trying to find a way to pass the arguments (buffer actually) that was send in the 'finish'.
passing the arguments as they came dont work, so i added a new event.